### PR TITLE
Fix multi query error

### DIFF
--- a/src/utils/keyedErrors.utils.ts
+++ b/src/utils/keyedErrors.utils.ts
@@ -1,23 +1,24 @@
 import { KeyedError } from '../types/metricsApi.types';
 
-export function mapKeyedErrorMessage(keyedError?: KeyedError): string {
+export function mapKeyedErrorMessage(keyedError?: KeyedError, queryRow?: string): string {
   const type = keyedError?.values?.type ?? 'error';
+  const queryRowPrefix = queryRow ? `Row ${queryRow}: ` : '';
 
   if (!keyedError) {
-    return `Unknown ${type} returned from the API`;
+    return `${queryRowPrefix}Unknown ${type} returned from the API`;
   }
 
   if (keyedError.values?.cause) {
-    return keyedError.values.cause;
+    return queryRowPrefix + keyedError.values.cause;
   }
 
   if (keyedError.values?.message) {
-    return keyedError.values?.message;
+    return queryRowPrefix + keyedError.values?.message;
   }
 
   if (keyedError.key) {
-    return `API return ${type} with code "${keyedError.key}"`;
+    return `${queryRowPrefix}API return ${type} with code "${keyedError.key}"`;
   }
 
-  return `Unknown returned from the API`;
+  return `${queryRowPrefix}Unknown returned from the API`;
 }


### PR DESCRIPTION
This PR fixes showing error when only one query failed, also it adds a row ID prefix in case of such error, so it become more clear what is actually failed.