### PR TITLE
Adding logs aggregate query support

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,29 +1,75 @@
-import React from 'react';
-import { Button, QueryField } from '@grafana/ui';
+import React, { useMemo } from 'react';
+import { Button, QueryField , Select } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
 import { SumoQuery } from '../types/metricsApi.types';
-
+import { SumoQueryType } from '../types/constants';
+ 
 type Props = QueryEditorProps<DataSource, SumoQuery>;
 
-export function QueryEditor({ query, onChange, onRunQuery }: Props) {
-  const onQueryTextChange = React.useCallback((changedQueryText: string) => {
-    onChange({ ...query, queryText: changedQueryText });
-  }, [query]);
+const selectOptions = [
+  {
+    value : SumoQueryType.Logs,
+    label : 'Logs'
+  },
+  {
+    value : SumoQueryType.Metrics,
+    label : 'Metrics'
+  }
+]
 
-  const { queryText } = query;
+export function QueryEditor(props: Props) {
+
+  const { queries , query , onChange , onRunQuery} = props
+
+  const onQueryTextChange = React.useCallback((changedQueryText: string) => {
+    onChange({ ...query, queryText: changedQueryText  });
+  }, [query , onChange]);
+
+  const { queryText , type , refId  } = query;
+
+  const onTypeChangeHandler = React.useCallback((selectedObj : { value?: SumoQueryType , label? : string })=>{
+    onChange({ ...query, type : selectedObj.value });
+  } , [query , onChange])
+
+
+  const isEditorDisabled = useMemo(()=>{
+    if(props.query.type === SumoQueryType.Logs){
+      return false;
+    }
+    // disable editor is there is any log query present
+    if(queries){
+      const logsQuery = queries.find((queryObj : SumoQuery )=>queryObj.type===SumoQueryType.Logs)
+      return logsQuery ? true : false
+    }
+
+    return false
+  } , [queries , query])
+
 
   return (
     <div style={{ display: 'flex', gap: '1rem' }}>
+      <div style={{width : '120px'}}>
+        <Select
+          options={selectOptions}
+          value={type  || SumoQueryType.Metrics}
+          onChange={onTypeChangeHandler}
+          disabled={isEditorDisabled}
+        />
+      </div>
+      
       <QueryField
         // if onRunQuery is not passed then you user would not be able to focus out from the QueryField
         onRunQuery={onRunQuery}
         onChange={onQueryTextChange}
-        placeholder="Metric Query"
+        placeholder= {type === SumoQueryType.Logs ? "Logs Query" : "Metric Query"}
         query={queryText || ''}
         portalOrigin="sumo-metrics"
+        disabled={isEditorDisabled}
+        key={refId + type}
       />
-      <Button onClick={onRunQuery}>Run</Button>
+      <Button disabled={isEditorDisabled} onClick={onRunQuery}>Run</Button>
     </div>
   );
 }
+

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,6 +1,6 @@
 import { DataQueryRequest, DataSourceInstanceSettings, TimeRange } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
-import { of } from 'rxjs';
+import { of ,  firstValueFrom } from 'rxjs';
 
 import { DataSource } from './datasource';
 import { SumoQuery } from './types/metricsApi.types';
@@ -262,21 +262,23 @@ describe('placeholder test', () => {
         data: queryMockResponse(),
       }));
 
-      const result = await createDataSource().query({
-        interval: '6h',
-        range: {
-          from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
-          to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
-        } as unknown as TimeRange,
-        maxDataPoints: 100,
-        targets: [{
-          queryText: 'metric=CPUFrequencyMHz_19',
-          refId: 'A',
-        }],
-        scopedVars: {
-          test: 'abc'
-        },
-      } as unknown as DataQueryRequest<SumoQuery>);
+      const result = await firstValueFrom(
+        createDataSource().query({
+          interval: '6h',
+          range: {
+            from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
+            to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
+          } as unknown as TimeRange,
+          maxDataPoints: 100,
+          targets: [{
+            queryText: 'metric=CPUFrequencyMHz_19',
+            refId: 'A',
+          }],
+          scopedVars: {
+            test: 'abc'
+          },
+        } as unknown as DataQueryRequest<SumoQuery>)
+      ) 
 
       expect(mockedFetch).toHaveBeenCalledWith({
         method: 'POST',
@@ -364,19 +366,21 @@ describe('placeholder test', () => {
         },
       }));
 
-      const result = await createDataSource().query({
-        interval: '6h',
-        range: {
-          from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
-          to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
-        } as unknown as TimeRange,
-        maxDataPoints: 100,
-        targets: [{
-          queryText: 'metric=CPUFrequencyMHz_19',
-          refId: 'A',
-        }],
-        scopedVars: {},
-      } as unknown as DataQueryRequest<SumoQuery>);
+      const result = await firstValueFrom(
+        createDataSource().query({
+          interval: '6h',
+          range: {
+            from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
+            to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
+          } as unknown as TimeRange,
+          maxDataPoints: 100,
+          targets: [{
+            queryText: 'metric=CPUFrequencyMHz_19',
+            refId: 'A',
+          }],
+          scopedVars: {},
+        } as unknown as DataQueryRequest<SumoQuery>)
+      ) 
 
       expect(result.data[0].meta.notices).toEqual([{
         severity: 'warning',
@@ -409,7 +413,7 @@ describe('placeholder test', () => {
         },
       }));
 
-      const result = await createDataSource().query({
+      const result = await firstValueFrom(createDataSource().query({
         interval: '6h',
         range: {
           from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
@@ -424,7 +428,7 @@ describe('placeholder test', () => {
           refId: 'B',
         }],
         scopedVars: {},
-      } as unknown as DataQueryRequest<SumoQuery>);
+      } as unknown as DataQueryRequest<SumoQuery>));
       
       expect(result.data[0].meta.notices).toEqual([]);
       expect(result.data[1].meta.notices).toEqual([]);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -63,7 +63,21 @@ export class DataSource extends DataSourceApi<SumoQuery> {
 
   fetchLogsQuery(options: DataQueryRequest<SumoQuery>) : Observable<DataQueryResponse>{
 
-    const { targets, range } = options;
+    const { targets, range , scopedVars } = options;
+
+    const templateSrv = getTemplateSrv();
+
+    const modifiledQueries : SumoQuery[] = targets
+    .filter(({ queryText }) => Boolean(queryText))
+    .map((query) => ({
+      ...query,
+      queryText: templateSrv.replace(query.queryText as string, scopedVars, interpolateVariable),
+    }));
+
+    if (!modifiledQueries.length) {
+      return of({ data : []})
+    }
+
     const logsQueryObj  = targets.find(query=>query.type === SumoQueryType.Logs) as SumoQuery
 
     const startTime = range.from.valueOf();

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -67,18 +67,19 @@ export class DataSource extends DataSourceApi<SumoQuery> {
 
     const templateSrv = getTemplateSrv();
 
-    const modifiledQueries : SumoQuery[] = targets
+    const modifiedQueries : SumoQuery[] = targets
     .filter(({ queryText }) => Boolean(queryText))
     .map((query) => ({
       ...query,
       queryText: templateSrv.replace(query.queryText as string, scopedVars, interpolateVariable),
     }));
 
-    if (!modifiledQueries.length) {
+
+    const logsQueryObj  = modifiedQueries.find(query=>query.type === SumoQueryType.Logs) as SumoQuery
+
+    if (!logsQueryObj) {
       return of({ data : []})
     }
-
-    const logsQueryObj  = targets.find(query=>query.type === SumoQueryType.Logs) as SumoQuery
 
     const startTime = range.from.valueOf();
     const endTime = range.to.valueOf();

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -18,7 +18,7 @@ import { interpolateVariable } from './utils/interpolation.utils';
 
 import { formatSumoValues, getSumoToGrafanaType, SumoQueryType } from './types/constants';
 import { searchQueryExecutionService } from './services/logDataService/searchQueryExecutionService';
-import { RunSearchActionType, SearchQueryType, SearchStatus } from './services/logDataService/constants';
+import { MAX_NUMBER_OF_RECORDS, RunSearchActionType, SearchQueryType, SearchStatus } from './services/logDataService/constants';
 import { IField, ISearchStatus, RunSearchAction, SearchQueryParams } from './services/logDataService/types';
 
 import { filter , switchMap } from 'rxjs/operators';
@@ -63,7 +63,7 @@ export class DataSource extends DataSourceApi<SumoQuery> {
 
   fetchLogsQuery(options: DataQueryRequest<SumoQuery>) : Observable<DataQueryResponse>{
 
-    const { targets, range , scopedVars } = options;
+    const { targets, range , scopedVars , maxDataPoints } = options;
 
     const templateSrv = getTemplateSrv();
 
@@ -81,6 +81,8 @@ export class DataSource extends DataSourceApi<SumoQuery> {
       return of({ data : []})
     }
 
+    const maxRecords = Math.min(maxDataPoints || MAX_NUMBER_OF_RECORDS , MAX_NUMBER_OF_RECORDS )
+
     const startTime = range.from.valueOf();
     const endTime = range.to.valueOf();
     const { queryText } = logsQueryObj 
@@ -94,7 +96,7 @@ export class DataSource extends DataSourceApi<SumoQuery> {
       basicAuth : this.basicAuth, 
       paginationInfo : {
         offset : 0,
-        length : 10000 // fetching first 10000 records only
+        length : maxRecords 
       }
     }
     const previousCountMap = {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -8,9 +8,7 @@ import {
   TimeRange,
 } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
-
-import { lastValueFrom } from 'rxjs';
-
+import { lastValueFrom , Observable , Subject , of , from , map } from 'rxjs';
 import { calculateInterval, createEpochTimeRangeBoundary } from './utils/time.utils';
 import { SumoApiDimensionValuesResponse } from './types/metadataCatalogApi.types';
 import { mapKeyedErrorMessage } from './utils/keyedErrors.utils';
@@ -18,24 +16,130 @@ import { MetricsQuery, SumoApiMetricsResponse, SumoQuery } from './types/metrics
 import { dimensionsToLabelSuffix } from './utils/labels.utils';
 import { interpolateVariable } from './utils/interpolation.utils';
 
+import { formatSumoValues, getSumoToGrafanaType, SumoQueryType } from './types/constants';
+import { searchQueryExecutionService } from './services/logDataService/searchQueryExecutionService';
+import { RunSearchActionType, SearchQueryType, SearchStatus } from './services/logDataService/constants';
+import { IField, ISearchStatus, RunSearchAction, SearchQueryParams } from './services/logDataService/types';
+
+import { filter , switchMap } from 'rxjs/operators';
+
 export class DataSource extends DataSourceApi<SumoQuery> {
   private readonly baseUrl: string;
   private readonly basicAuth: string;
+
+  private logsController$ :  Subject<RunSearchAction> | null
 
   constructor(instanceSettings: DataSourceInstanceSettings) {
     super(instanceSettings);
     this.baseUrl = instanceSettings.url as string;
     this.basicAuth = instanceSettings.basicAuth as string;
+    this.logsController$ = null
   }
 
-  // perform metrics query by Grafana
-  async query(options: DataQueryRequest<SumoQuery>): Promise<DataQueryResponse> {
-    const { range, maxDataPoints, targets, scopedVars, interval } = options;
-    const templateSrv = getTemplateSrv();
+  // perform logs/metrics query by Grafana
+  query(options: DataQueryRequest<SumoQuery>): Observable<DataQueryResponse> {
+    const { range , targets } = options;
 
     if (!range) {
       throw new Error('No range has been provided');
     }
+    if(this.logsController$){
+      // stop previous running logs query
+      this.logsController$.next({ type : RunSearchActionType.STOP })
+      this.logsController$ = null;
+    }
+
+    //Check if any logs query present
+    const isLogsQuery = targets.find(query=>query.type === SumoQueryType.Logs)
+
+    if(isLogsQuery){
+      return this.fetchLogsQuery(options);
+    }
+    else{
+      return this.fetchMetricsQuery(options);
+    }
+  }
+
+
+  fetchLogsQuery(options: DataQueryRequest<SumoQuery>) : Observable<DataQueryResponse>{
+
+    const { targets, range } = options;
+    const logsQueryObj  = targets.find(query=>query.type === SumoQueryType.Logs) as SumoQuery
+
+    const startTime = range.from.valueOf();
+    const endTime = range.to.valueOf();
+    const { queryText } = logsQueryObj 
+
+    const searchParams : SearchQueryParams = {
+      types: [SearchQueryType.AGGREGATE],
+      query: queryText || '',
+      startTime : startTime,
+      endTime : endTime,
+      baseUrl : this.baseUrl,
+      basicAuth : this.basicAuth, 
+      paginationInfo : {
+        offset : 0,
+        length : 10000 // fetching first 10000 records only
+      }
+    }
+    const previousCountMap = {
+      messageCount : 0
+    }
+
+    const searchStatusFilter = (status$: Observable<ISearchStatus>) =>
+    status$.pipe(
+      filter((searchStatusResponse: ISearchStatus) => {
+        const isMessageCountUpdated = searchStatusResponse.messageCount && searchStatusResponse.messageCount > previousCountMap.messageCount ? true : false
+        if(isMessageCountUpdated){
+          previousCountMap.messageCount = searchStatusResponse.messageCount as number
+        }
+
+        const isQueryCompleted = searchStatusResponse.state === SearchStatus.DONE_GATHERING_RESULTS
+
+        return (
+          //fetching records when messages count changes and when query gets completed
+          isMessageCountUpdated || isQueryCompleted
+        );
+      }),
+    );
+
+    this.logsController$ = new Subject();
+
+    return searchQueryExecutionService.run(
+      searchParams,
+      this.logsController$,
+      searchStatusFilter
+    ).pipe(switchMap(response=>{
+      const aggregateResponse = response.aggregate
+      if(!aggregateResponse){
+        return of({
+          data  : []
+        }) as  Observable<DataQueryResponse>
+      }
+      const {fields , records} = aggregateResponse
+
+      const dataFrame = new MutableDataFrame({
+        name : 'AggregateResponse', // dataframe name
+        fields: fields.map((field : IField)=>{
+          return{
+            name : field.name,
+            type :  getSumoToGrafanaType(field.name , field.fieldType),
+            values : records.map(record=> formatSumoValues(record.map[field.name] , field.fieldType )),
+          }
+        }),
+      })
+      return of({ data : [dataFrame] })
+    }),
+    filter(value=>value.data.length>0)
+    )
+  }
+
+
+  fetchMetricsQuery(options: DataQueryRequest<SumoQuery>) : Observable<DataQueryResponse>{
+
+    const { range, maxDataPoints, targets, scopedVars, interval } = options;
+
+    const templateSrv = getTemplateSrv();
 
     const startTime = range.from.valueOf();
     const endTime = range.to.valueOf();
@@ -55,64 +159,64 @@ export class DataSource extends DataSourceApi<SumoQuery> {
       }));
 
     if (!queries.length) {
-      return {
-        data: []
-      };
+      return of({ data : []})
     }
 
     const hasMultipleQueries = queries.length > 1;
 
-    const { data: { response, keyedErrors, error, errorKey, errorMessage } } = await this.fetchMetrics(queries, {
+    return from(this.fetchMetrics(queries, {
       startTime,
       endTime,
       requestedDataPoints,
       maxDataPoints: maxDataPoints ?? 100,
       desiredQuantizationInSec,
-    });
-
-    if (error && !response.length) {
-      if (errorMessage) {
-        throw new Error(errorMessage);
-      }
-
-      if (errorKey) {
-        throw new Error(`API return error with code "${errorKey}"`);
-      }
-
-      const firstKeyedError = keyedErrors.find((keyedError) => keyedError.values?.type === 'error');
-      const firstWarningError = keyedErrors.find((keyedError) => keyedError.values?.type === 'warning');
-
-      throw new Error(mapKeyedErrorMessage(firstKeyedError ?? firstWarningError));
-    }
-
-    const data = response.flatMap(({ rowId, results }) => {
-      const responseSpecificErrors = hasMultipleQueries
-        ? keyedErrors.filter(({ values }) => values?.rowId === rowId)
-        : keyedErrors;
-      const notices = responseSpecificErrors
-        .map(keyedError => ({
-          text: mapKeyedErrorMessage(keyedError, hasMultipleQueries ? rowId : undefined),
-          severity: keyedError.values?.type ?? 'error',
-        }));
-      return results.length
-        ? results.map(({ metric, datapoints }) => new MutableDataFrame({
-          name: `${metric.name} ${dimensionsToLabelSuffix(metric.dimensions)}`.trim(),
-          refId: rowId,
-          meta: { notices },
-          fields: [
-            { name: 'Time', values: datapoints.timestamp, type: FieldType.time},
-            { name: 'Value', values: datapoints.value, type: FieldType.number}
-          ]
-        }))
-        : new MutableDataFrame({
-          name: `${rowId}`,
-          refId: rowId,
-          meta: { notices, },
-          fields: []
+    })).pipe(
+      map(res=>{
+        const { data: { response, keyedErrors, error, errorKey, errorMessage } } = res;
+        if (error && !response.length) {
+          if (errorMessage) {
+            throw new Error(errorMessage);
+          }
+    
+          if (errorKey) {
+            throw new Error(`API return error with code "${errorKey}"`);
+          }
+    
+          const firstKeyedError = keyedErrors.find((keyedError) => keyedError.values?.type === 'error');
+          const firstWarningError = keyedErrors.find((keyedError) => keyedError.values?.type === 'warning');
+    
+          throw new Error(mapKeyedErrorMessage(firstKeyedError ?? firstWarningError));
+        }
+    
+        const data = response.flatMap(({ rowId, results }) => {
+          const responseSpecificErrors = hasMultipleQueries
+            ? keyedErrors.filter(({ values }) => values?.rowId === rowId)
+            : keyedErrors;
+          const notices = responseSpecificErrors
+            .map(keyedError => ({
+              text: mapKeyedErrorMessage(keyedError, hasMultipleQueries ? rowId : undefined),
+              severity: keyedError.values?.type ?? 'error',
+            }));
+          return results.length
+            ? results.map(({ metric, datapoints }) => new MutableDataFrame({
+              name: `${metric.name} ${dimensionsToLabelSuffix(metric.dimensions)}`.trim(),
+              refId: rowId,
+              meta: { notices },
+              fields: [
+                { name: 'Time', values: datapoints.timestamp, type: FieldType.time},
+                { name: 'Value', values: datapoints.value, type: FieldType.number}
+              ]
+            }))
+            : new MutableDataFrame({
+              name: `${rowId}`,
+              refId: rowId,
+              meta: { notices, },
+              fields: []
+            });
         });
-    });
-
-    return { data };
+        return { data }   
+      })
+    )
   }
 
   // used to get Query dependent variables by Grafana

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,4 +6,4 @@ import { SumoQuery } from './types/metricsApi.types';
 
 export const plugin = new DataSourcePlugin<DataSource, SumoQuery>(DataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor);
+  .setQueryEditor(QueryEditor)

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
-  "name": "Sumo Logic Metrics",
+  "name": "Sumo Logic",
   "id": "sumologic-metrics-datasource",
   "metrics": true,
   "info": {
-    "description": "Sumo Logic Metrics for Grafana",
+    "description": "Sumo Logic Logs & Metrics for Grafana",
     "author": {
       "name": "Sumo Logic",
       "url": "https://www.sumologic.com"

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -4,6 +4,7 @@
   "name": "Sumo Logic",
   "id": "sumologic-metrics-datasource",
   "metrics": true,
+  "logs": true,
   "info": {
     "description": "Sumo Logic Logs & Metrics for Grafana",
     "author": {

--- a/src/services/logDataService/constants.ts
+++ b/src/services/logDataService/constants.ts
@@ -1,0 +1,31 @@
+
+
+export enum RunSearchActionType {
+    SET_PAGE = 'Page',
+    PAUSE = 'Pause',
+    STOP = 'Stop',
+  }
+
+export enum SearchStatus {
+    NOT_STARTED = 'NOT STARTED',
+    GATHERING_RESULTS = 'GATHERING RESULTS',
+    FORCE_PAUSED = 'FORCE PAUSED',
+    DONE_GATHERING_RESULTS = 'DONE GATHERING RESULTS',
+    CANCELLED = 'CANCELLED',
+}
+
+export const QUERY_STOPPED_STATES : any = {
+    [SearchStatus.DONE_GATHERING_RESULTS]: true,
+    [SearchStatus.CANCELLED]: true,
+    [SearchStatus.FORCE_PAUSED]: true,
+};
+
+export enum SearchQueryType {
+    MESSAGES = 'message',
+    AGGREGATE = 'aggregate',
+  }
+
+  
+export const MESSAGES_RETRY_COUNT = 100;
+export const MESSAGES_RETRY_DELAY = 3000;
+export const MESSAGES_RETRY_EMPTY_ERROR = 'MESSAGES_RETRY_EMPTY_ERROR';

--- a/src/services/logDataService/constants.ts
+++ b/src/services/logDataService/constants.ts
@@ -29,3 +29,5 @@ export enum SearchQueryType {
 export const MESSAGES_RETRY_COUNT = 100;
 export const MESSAGES_RETRY_DELAY = 3000;
 export const MESSAGES_RETRY_EMPTY_ERROR = 'MESSAGES_RETRY_EMPTY_ERROR';
+
+export const MAX_NUMBER_OF_RECORDS = 10000

--- a/src/services/logDataService/searchQueryDataService.ts
+++ b/src/services/logDataService/searchQueryDataService.ts
@@ -5,6 +5,9 @@ import { lastValueFrom } from 'rxjs';
 
 import { ISearchAggregateResult, ISearchQueryDataService, ISearchStatus, ISearchCreate, SearchQueryParams } from './types';
 
+
+const SEARCH_JOB_API = '/v1/search/jobs'
+
 export class SearchQueryDataService implements ISearchQueryDataService {
 
   create(
@@ -25,7 +28,7 @@ export class SearchQueryDataService implements ISearchQueryDataService {
       headers: {
         Authorization: basicAuth,
       },
-      url: baseUrl + '/v1/search/jobs',
+      url: baseUrl + SEARCH_JOB_API,
       data,
     })).then(response => response.data);
   }
@@ -37,7 +40,7 @@ export class SearchQueryDataService implements ISearchQueryDataService {
       headers: {
         Authorization: basicAuth,
       },
-      url: baseUrl + '/v1/search/jobs/' + searchQuerySessionId,
+      url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}` ,
     })).then(response => response.data)
   }
 
@@ -48,7 +51,7 @@ export class SearchQueryDataService implements ISearchQueryDataService {
       headers: {
         Authorization: basicAuth,
       },
-      url: baseUrl + '/v1/search/jobs/' + searchQuerySessionId,
+      url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}`,
     })).then(response => response.data)
   }
 
@@ -69,7 +72,7 @@ export class SearchQueryDataService implements ISearchQueryDataService {
         offset,
         limit : length,
       },
-      url: baseUrl + '/v1/search/jobs/' + searchQuerySessionId + '/messages',
+      url:  `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}/messages`,
     })).then(response => response.data)
   }
 
@@ -91,7 +94,7 @@ export class SearchQueryDataService implements ISearchQueryDataService {
         offset,
         limit : length,
       },
-      url: baseUrl + '/v1/search/jobs/' + searchQuerySessionId + '/records',
+      url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}/records`,
     })).then(response => response.data)
   }
 }

--- a/src/services/logDataService/searchQueryDataService.ts
+++ b/src/services/logDataService/searchQueryDataService.ts
@@ -1,0 +1,99 @@
+
+
+import { getBackendSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
+
+import { ISearchAggregateResult, ISearchQueryDataService, ISearchStatus, ISearchCreate, SearchQueryParams } from './types';
+
+export class SearchQueryDataService implements ISearchQueryDataService {
+
+  create(
+    searchQueryParams : Omit<SearchQueryParams , 'paginationInfo' | 'types' >  
+  ): Promise<ISearchCreate> {
+
+    const { query , startTime , endTime  , baseUrl , basicAuth } = searchQueryParams
+    const data = {
+      query,
+      from : startTime,
+      to : endTime,
+      byReceiptTime: true
+
+    };
+    return  lastValueFrom(getBackendSrv().fetch<ISearchCreate>({
+      method : 'POST',
+      credentials: 'include',
+      headers: {
+        Authorization: basicAuth,
+      },
+      url: baseUrl + '/v1/search/jobs',
+      data,
+    })).then(response => response.data);
+  }
+
+  status(searchQuerySessionId: string , baseUrl : string , basicAuth:string): Promise<ISearchStatus> {
+    return lastValueFrom(getBackendSrv().fetch<ISearchStatus>({
+      method : 'GET',
+      credentials: 'include',
+      headers: {
+        Authorization: basicAuth,
+      },
+      url: baseUrl + '/v1/search/jobs/' + searchQuerySessionId,
+    })).then(response => response.data)
+  }
+
+  delete(searchQuerySessionId: string , baseUrl : string , basicAuth  :string): Promise<any>{
+    return lastValueFrom(getBackendSrv().fetch<ISearchStatus>({
+      method : 'DELETE',
+      credentials: 'include',
+      headers: {
+        Authorization: basicAuth,
+      },
+      url: baseUrl + '/v1/search/jobs/' + searchQuerySessionId,
+    })).then(response => response.data)
+  }
+
+  messages(
+    searchQuerySessionId: string,
+    offset: number,
+    length: number,
+    baseUrl : string,
+    basicAuth : string,
+  ): Promise<any> {
+    return lastValueFrom(getBackendSrv().fetch<ISearchAggregateResult>({
+      method : 'GET',
+      credentials: 'include',
+      headers: {
+        Authorization: basicAuth,
+      },
+      params : {
+        offset,
+        limit : length,
+      },
+      url: baseUrl + '/v1/search/jobs/' + searchQuerySessionId + '/messages',
+    })).then(response => response.data)
+  }
+
+  aggregates(
+    searchQuerySessionId: string,
+    offset: number,
+    length: number,
+    baseUrl : string,
+    basicAuth : string,
+  ): Promise<any> {
+
+    return lastValueFrom(getBackendSrv().fetch<ISearchAggregateResult>({
+      method : 'GET',
+      credentials: 'include',
+      headers: {
+        Authorization: basicAuth,
+      },
+      params : {
+        offset,
+        limit : length,
+      },
+      url: baseUrl + '/v1/search/jobs/' + searchQuerySessionId + '/records',
+    })).then(response => response.data)
+  }
+}
+
+export const searchQueryDataService = new SearchQueryDataService();

--- a/src/services/logDataService/searchQueryExecutionService.ts
+++ b/src/services/logDataService/searchQueryExecutionService.ts
@@ -1,0 +1,376 @@
+import type { Observable } from 'rxjs';
+import {
+  from,
+  combineLatest,
+  Subject,
+  throwError,
+  of,
+  merge,
+  defer,
+} from 'rxjs';
+import {
+  mergeMap,
+  switchMap,
+  share,
+  repeatWhen,
+  delay,
+  takeUntil,
+  startWith,
+  filter,
+  retryWhen,
+  take,
+  takeWhile,
+  publish,
+  skipWhile,
+  merge as mergeOprator
+} from 'rxjs/operators';
+
+
+
+export const takeWhileInclusive = <T>(predicate: (value: T, index: number) => boolean) =>
+  (source: Observable<T>) =>
+    source.pipe(
+      publish((co) =>
+        co.pipe(
+          takeWhile(predicate),
+          mergeOprator(co.pipe(skipWhile(predicate), take(1))),
+        ),
+      ),
+    );
+
+import { searchQueryDataService } from './searchQueryDataService';
+import { MESSAGES_RETRY_COUNT, MESSAGES_RETRY_DELAY, MESSAGES_RETRY_EMPTY_ERROR, QUERY_STOPPED_STATES, RunSearchActionType, SearchQueryType } from './constants';
+import { ISearchMessageResult, ISearchStatus, ISearchCreate, RetrievePageFunction, RunSearchAction, SearchPaginationInfo, SearchQueryParams, SearchResult, SearchStatusFilter } from './types';
+
+export class SearchQueryExecutionService {
+  public run(
+    searchParams: SearchQueryParams,
+    control$: Observable<RunSearchAction>,
+    statusFilter: SearchStatusFilter,
+
+  ): Observable<SearchResult> {
+    // Create a search
+    const { query, startTime, endTime, baseUrl, basicAuth, timeZone } = searchParams;
+    const create$ = from(
+      searchQueryDataService.create({
+        query,
+        startTime,
+        endTime,
+        baseUrl,
+        basicAuth,
+        timeZone
+      }
+      ),
+    );
+    return create$.pipe(
+      mergeMap((response: ISearchCreate) => {
+        // Transform promise observable into search result observable
+        return this.runSearchWithQueryId(
+          response.id,
+          searchParams,
+          control$,
+          statusFilter,
+        );
+      }),
+    );
+  }
+
+  // The rest of the methods are meant to be private but are public to enable unit testing
+  runSearchWithQueryId(
+    searchQueryId: string,
+    searchParams: SearchQueryParams,
+    control$: Observable<RunSearchAction>,
+    statusFilter: SearchStatusFilter,
+  ): Observable<SearchResult> {
+
+
+    const { baseUrl, basicAuth } = searchParams
+
+    // Listen for control$ actions
+    const stop$ = control$.pipe(
+      switchMap((runSearchAction) => {
+        switch (runSearchAction.type) {
+          case RunSearchActionType.STOP:
+            return searchQueryDataService.delete(
+              searchQueryId,
+              baseUrl,
+              basicAuth
+            );
+          default:
+            throw new Error(
+              `Action type not supported in control$: ${runSearchAction.type}`,
+            );
+        }
+      }),
+      share(),
+    );
+
+    // Make status observable
+    const status$ = this.runGetStatus(searchQueryId, baseUrl, basicAuth, stop$);
+
+    // Use status observable as input to raw messages and aggregate query observables
+    const types = searchParams.types;
+    const observablesByType: Observable<ISearchMessageResult>[] = []; // Array of results matching index of types
+
+    // Execute search type specific logic
+    types.forEach((queryType: string) => {
+      switch (queryType) {
+        case SearchQueryType.MESSAGES:
+          observablesByType.push(
+            this.runGetMessages(
+              searchQueryId,
+              searchParams.paginationInfo,
+              baseUrl,
+              basicAuth,
+              status$,
+              control$,
+              statusFilter,
+            ),
+          );
+          break;
+        case SearchQueryType.AGGREGATE:
+          observablesByType.push(
+            this.runGetAggregates(
+              searchQueryId,
+              baseUrl,
+              basicAuth,
+              searchParams.paginationInfo,
+              status$,
+              control$,
+              statusFilter,
+            ),
+          );
+          break;
+        default:
+          break;
+      }
+    });
+
+    // Result selector to pass into combineLatest.
+    const resultSelector = (status: ISearchStatus, ...resultByType: any[]) => {
+      const combinedResult : any = { status };
+      resultByType.forEach((result, index) => {
+        combinedResult[types[index]] = result; 
+      });
+
+      return combinedResult;
+    };
+
+    // Push result selector into observablesByType so it can be the last parameter
+    const params: any = [status$, ...observablesByType, resultSelector];
+
+    // Return unified observable with the result of [status, messages?, aggregate?]
+    // The observable completes when all the combined observables complete
+    const searchResultCombined$: Observable<SearchResult> = combineLatest.apply(
+      this,
+      params,
+    ) as Observable<SearchResult>;
+
+    return searchResultCombined$.pipe(takeUntil(stop$));
+  }
+
+  /**
+   * Continuously polls for getStatus until pollCondition is met
+   * Ex:
+   * NOT_STARTED -> GATHERING_RESULTS  -> GATHERING_RESULTS -> GATHERING_RESULTS -> DONE_GATHERING_RESULTS
+   * @param searchQueryId
+   * @returns {Observable<ISearchStatus>}
+   */
+  runGetStatus(
+    searchQueryId: string,
+    baseUrl: string,
+    basicAuth: string,
+    stop$: Observable<{}>,
+  ): Observable<ISearchStatus> {
+    // If we make poll condition configurable then it becomes similar to statusFilter.  statusFilter is more like
+    // filtering statuses for a desired one, while poll condition controls polling itself.  Is this something
+    // we should allow the caller to specify or should we just let them filter for the desired statuses?
+    const pollCondition = (statusResponse: ISearchStatus) =>
+      !QUERY_STOPPED_STATES[statusResponse.state];
+
+    const statusSubject = new Subject<ISearchStatus>();
+
+    defer(() => searchQueryDataService.status(searchQueryId, baseUrl, basicAuth))
+      .pipe(
+        // TODO remove takeUntil(stop$) once SUMO-97437 is solved
+        // Currently, we need to take stop$ into account as well becase pausing a raw query doesn't always
+        // result in change of state in subsequent status calls. Therefore, the check in pollCondition
+        // may not be sufficient.
+        repeatWhen((notifications) =>
+          notifications.pipe(delay(1000), takeUntil(stop$)),
+        ),
+        takeWhileInclusive(pollCondition),
+      )
+      .subscribe((status: ISearchStatus) => {
+        statusSubject.next(status);
+      });
+
+    return statusSubject.asObservable();
+  }
+
+  /**
+   * Call the get raw messages api endpoint and places results in an observable.
+   * The message observable starts when a condition on the status$ is met.  This condition is specified by statusFilter.
+   * So if statusFilter returns true only when the status is DONE_GATHERING_RESULTS, the observable will look like this:
+   *
+   * Status Observable: NOT_STARTED -> GATHERING_RESULTS -> GATHERING_RESULTS -> DONE_GATHERING_RESULTS
+   *                                                                                  |
+   * Message Observable:                                                          MESSAGE (PAGE 1)
+   * @param paginationInfo
+   * @param status$
+   * @param control$
+   * @param statusFilter
+   * @returns {Observable<ISearchMessageResult>}
+   */
+  runGetMessages(
+    searchQueryId: string,
+    paginationInfo: SearchPaginationInfo,
+    baseUrl: string,
+    basicAuth: string,
+    status$: Observable<ISearchStatus>,
+    control$: Observable<RunSearchAction>,
+    statusFilter: SearchStatusFilter,
+  ): Observable<ISearchMessageResult> {
+    const messages$ = statusFilter(status$).pipe(
+      switchMap((searchStatusResponse: ISearchStatus) => {
+        // Switch to a message promise once condition is met
+        if (searchStatusResponse.messageCount! > 0) {
+          return this.fetchMessagesWithRetry(
+            searchQueryId,
+            baseUrl,
+            basicAuth,
+            paginationInfo,
+          );
+        } else if (searchStatusResponse?.pendingErrors?.[0]) {
+          // Throw an error because the /create call also will trigger an observable error and we want to be consisten
+          return throwError(
+            new Error(searchStatusResponse.pendingErrors[0]),
+          );
+        } else {
+          return of(undefined);
+        }
+      }),
+    );
+
+    return merge(
+      messages$,
+      this.addPagingForControlObservable(
+        control$,
+        baseUrl,
+        basicAuth,
+        searchQueryDataService.messages,
+      ),
+    ).pipe(
+      startWith(undefined), // Start with undefined so that combineLatest will take status without messages;
+    ) as Observable<ISearchMessageResult>;
+  }
+
+  runGetAggregates(
+    searchQueryId: string,
+    baseUrl: string,
+    basicAuth: string,
+    paginationInfo: SearchPaginationInfo,
+    status$: Observable<ISearchStatus>,
+    control$: Observable<RunSearchAction>,
+    statusFilter: SearchStatusFilter,
+  ) {
+    const aggregate$ = statusFilter(status$).pipe(
+      switchMap((searchStatusResponse: ISearchStatus) => {
+        if (searchStatusResponse.recordCount! > 0) {
+          return searchQueryDataService.aggregates(
+            searchQueryId,
+            paginationInfo.offset,
+            paginationInfo.length,
+            baseUrl,
+            basicAuth
+          );
+        } else if (searchStatusResponse?.pendingErrors?.[0]) {
+          // Throw an error because the /create call also will trigger an observable error and we want to be consisten
+          return throwError(
+            new Error(searchStatusResponse.pendingErrors[0]),
+          );
+        } else {
+          return of(undefined);
+        }
+      }),
+    );
+
+    return merge(
+      aggregate$,
+      this.addPagingForControlObservable(
+        control$,
+        baseUrl,
+        basicAuth,
+        searchQueryDataService.aggregates,
+      ),
+    ).pipe(
+      startWith(undefined), // Start with undefined so that combineLatest will take status without messages;
+    );
+  }
+
+  // This method retries because of a bug in search (SUMO-97298). It can happen that
+  // even though `rawMessageCount` is greater then zero, the subsequent call to `messages`
+  // returns empty message array.
+  private fetchMessagesWithRetry(
+    searchQueryId: string,
+    baseUrl: string,
+    basicAuth: string,
+    paginationInfo: SearchPaginationInfo,
+  ) {
+    return defer(() =>
+      searchQueryDataService.messages(
+        searchQueryId,
+        paginationInfo.offset,
+        paginationInfo.length,
+        baseUrl,
+        basicAuth
+      ),
+    ).pipe(
+      switchMap((result) =>
+        result.messages.length
+          ? of(result)
+          : throwError(new Error(MESSAGES_RETRY_EMPTY_ERROR)),
+      ),
+      retryWhen((error$) =>
+        error$.pipe(
+          filter(
+            (error: Error) => error.message === MESSAGES_RETRY_EMPTY_ERROR,
+          ),
+          delay(MESSAGES_RETRY_DELAY),
+          take(MESSAGES_RETRY_COUNT),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Handles the SET_PAGE RunSearchActionType in the control$ observable.
+   * NOTE: There is no restriction on when the page of messages can be set.  The code emitting events to control$ may want to retrieve
+   * the second page before the first page, or retrieve results when the search status is still GATHERING RESULTS.
+   * @param control$
+   * @param retrievePageFunction
+   * @returns {Observable<any>}
+   */
+  private addPagingForControlObservable(
+    control$: Observable<RunSearchAction>,
+    baseUrl: string,
+    basicAuth: string,
+    retrievePageFunction: RetrievePageFunction,
+  ): Observable<any> {
+    return control$.pipe(
+      filter(
+        (runSearchAction) =>
+          runSearchAction.type === RunSearchActionType.SET_PAGE,
+      ),
+      switchMap((runSearchAction) => {
+        const {
+          sessionId,
+          paginationInfo: { offset, length },
+        } = runSearchAction.payload;
+        return retrievePageFunction(sessionId, offset, length, baseUrl, basicAuth);
+      }),
+    );
+  }
+}
+
+export const searchQueryExecutionService = new SearchQueryExecutionService();

--- a/src/services/logDataService/types.ts
+++ b/src/services/logDataService/types.ts
@@ -101,3 +101,4 @@ export type RetrievePageFunction = (
     baseUrl: string,
     basicAuth: string
 ) => Promise<any>;
+

--- a/src/services/logDataService/types.ts
+++ b/src/services/logDataService/types.ts
@@ -1,0 +1,103 @@
+import type { Observable } from 'rxjs';
+import { RunSearchActionType, SearchQueryType, SearchStatus } from './constants';
+
+
+export interface ISearchQueryDataService {
+    create: (
+        searchQueryParams: Omit<SearchQueryParams, 'paginationInfo' | 'types'>
+    ) => Promise<ISearchCreate>;
+    status: (searchQuerySessionId: string, baseUrl: string, basicAuth: string) => Promise<ISearchStatus>;
+    delete: (searchQuerySessionId: string, baseUrl: string, basicAuth: string) => Promise<any>;
+    messages: (
+        searchQuerySessionId: string,
+        offset: number,
+        length: number,
+        baseUrl: string,
+        basicAuth: string,
+    ) => Promise<ISearchMessageResult>;
+    aggregates: (
+        searchQuerySessionId: string,
+        offset: number,
+        length: number,
+        baseUrl: string,
+        basicAuth: string,
+    ) => Promise<ISearchAggregateResult>;
+}
+
+export interface ISearchCreate {
+    id: string;
+}
+
+
+export type SearchStatusFilter = (
+    searchObservable: Observable<ISearchStatus>,
+) => Observable<ISearchStatus>;
+
+
+
+export interface SearchPaginationInfo {
+    offset: number;
+    length: number;
+    hasMore?: boolean;
+    totalResults?: number;
+}
+
+export interface SearchQueryParams {
+    types: SearchQueryType[];
+    query: string;
+    startTime: number,
+    endTime: number,
+    timeZone?: string;
+    baseUrl: string,
+    basicAuth: string,
+    paginationInfo: SearchPaginationInfo;
+}
+
+export interface RunSearchAction {
+    type: RunSearchActionType;
+    payload?: any;
+}
+
+export interface ISearchStatus {
+    state: SearchStatus;
+    messageCount?: number;
+    recordCount?: number;
+    pendingErrors?: any[];
+    pendingWarnings?: any[];
+}
+
+export interface IField {
+    name: string,
+    fieldType: string,
+    keyField: boolean
+}
+
+export interface IRecords {
+    map: Record<string, string>
+}
+
+export interface ISearchAggregateResult {
+    fields: IField[];
+    records: IRecords[];
+}
+
+export interface ISearchMessageResult {
+    fields: IField[];
+    messages: IRecords[];
+}
+
+export interface SearchResult {
+    status: ISearchStatus;
+    // These keys should match SearchQueryType enum
+    message?: ISearchMessageResult;
+    aggregate?: ISearchAggregateResult;
+}
+
+
+export type RetrievePageFunction = (
+    sessionId: string,
+    offset: number,
+    length: number,
+    baseUrl: string,
+    basicAuth: string
+) => Promise<any>;

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -1,0 +1,28 @@
+import { FieldType } from "@grafana/data";
+
+export const enum SumoQueryType{
+    Logs = 'Logs',
+    Metrics = 'Metrics'
+}
+
+export const SumoToGrafanaTypeMap : Record<string , FieldType> = {
+    int : FieldType.number,
+    double : FieldType.number,
+    string : FieldType.string,
+}
+
+export const getSumoToGrafanaType  = (fieldName : string , fieldType : string) : FieldType =>{
+    if(fieldName === '_timeslice'){
+        return FieldType.time
+    }
+
+    return SumoToGrafanaTypeMap[fieldType] || FieldType.string;
+}
+
+
+export const formatSumoValues = (value : string, type : string)=>{
+    if(type === 'int' || type === 'double' || type==='long'){
+        return Number(value)
+    }
+    return value
+}

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -26,3 +26,4 @@ export const formatSumoValues = (value : string, type : string)=>{
     }
     return value
 }
+

--- a/src/types/metricsApi.types.ts
+++ b/src/types/metricsApi.types.ts
@@ -1,4 +1,5 @@
 import { DataQuery } from '@grafana/data';
+import { SumoQueryType } from './constants';
 
 export interface MetricResultDetailsDimensions {
   key: string;
@@ -81,4 +82,5 @@ export interface MetricsQuery {
 
 export interface SumoQuery extends DataQuery {
   queryText?: string;
+  type?: SumoQueryType
 }


### PR DESCRIPTION
In This PR we have added support for non aggregate query in grafana data source plugin. Include following changes.

- Added dropdown from where user can select what type query eg : Logs or metrics
- For now we have added support for single aggregate query that mean if user select **Logs** then it will automatically disable or other query component.

Demo Video :
 

https://github.com/SumoLogic-Labs/sumologic-metrics-grafana-datasource/assets/97428361/34dcac35-74d3-4644-91f7-c670de67c0fb

